### PR TITLE
removed chdir line - unnecessary (and doesn't work for me)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,9 @@
 # encoding: utf8
 
 import sys
-import os
-import glob
 import shutil
 
 from distutils.core import setup
-
-os.chdir(os.path.dirname(sys.argv[0]))
 
 shutil.copy("logo.pdf", "cvcreator/templates")
 
@@ -16,7 +12,7 @@ setup(
     name='cvcreator',
     version='0.4',
     packages=['cvcreator'],
-    package_data = {"cvcreator": ["templates/*"]},
+    package_data={"cvcreator": ["templates/*"]},
     url='http://github.com/ExpertAnalytics/cvcreator',
     author="Jonathan Feinberg",
     author_email="jonathan@xal.no",
@@ -27,6 +23,7 @@ if sys.version_info.major == 2:
     src = "frontend2.py"
 else:
     src = "frontend3.py"
+
 
 def copy_script():
 


### PR DESCRIPTION

@jonathf  - just did some pep8, and removed the chdir which doesn't seem to work when I run this as 'python setup.py install' which is the standard way to run it..

Btw, should the frontend script be installed with another name, frontend3 doesn't seem very intuitive. cvcreator would have been better maybe?