### PR TITLE
RH suggestions

### DIFF
--- a/cvcreator/workspace.py
+++ b/cvcreator/workspace.py
@@ -139,9 +139,9 @@ class cvopen(object):
             print("latexmk run failed, see errors above ^^^")
             print("trying pdflatex instead...")
             cmd = (" %s pdflatex \"%s\" %s "
-                    "-latexoption=\"-interaction=nonstopmode\" %s"
+                    "-latexoption=\"-interaction=nonstopmode\""
                     % (separator, texname, silentstr))
-            cmd = ("cd \"%s\"" % (self.path)) + cmd + cmd 
+            cmd = ("cd \"%s\"" % (self.path)) + cmd + cmd
             p = subprocess.Popen(cmd, shell=True)
             p.wait()
             if (p.returncode): #Non-zero return code from call to latexmk

--- a/cvcreator/workspace.py
+++ b/cvcreator/workspace.py
@@ -138,9 +138,10 @@ class cvopen(object):
         if (p.returncode): #Non-zero return code from call to latexmk
             print("latexmk run failed, see errors above ^^^")
             print("trying pdflatex instead...")
-            cmd = ("cd \"%s\" %s pdflatex \"%s\" %s "
-                    "-latexoption=\"-interaction=nonstopmode\""
-                    % (self.path, separator, texname, silentstr))
+            cmd = (" %s pdflatex \"%s\" %s "
+                    "-latexoption=\"-interaction=nonstopmode\" %s"
+                    % (separator, texname, silentstr))
+            cmd = ("cd \"%s\"" % (self.path)) + cmd + cmd 
             p = subprocess.Popen(cmd, shell=True)
             p.wait()
             if (p.returncode): #Non-zero return code from call to latexmk

--- a/cvcreator/workspace.py
+++ b/cvcreator/workspace.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import tempfile
 import yaml
+import subprocess
 
 import cvcreator
 
@@ -104,33 +105,46 @@ class cvopen(object):
             self.template_not_found(template)
 
         with open(self.path + template + ".yaml") as f:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
 
     def get_content(self):
         with open(self.path + "_content") as f:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
 
     def get_config(self):
         with open(self.path + "config.yaml") as f:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
 
     def compile(self, textxt, silent):
 
-        texname = self.path + self.target[:-3] + "tex"
-        with open(texname, "w") as f:
+        texname = self.target[:-3] + "tex"
+        with open(self.path + texname, "w") as f:
             f.write(textxt)
 
+        #print("wrote %s" % (self.path + texname))
         if silent:
-            os.system(
-                "cd %s; "
-                "latexmk %s -silent -pdf -latexoption=\"-interaction=nonstopmode\"" % (
-                    self.path, texname))
+            silentstr = "-silent"
         else:
-            os.system(
-                "cd %s; "
-                "latexmk %s -pdf -latexoption=\"-interaction=nonstopmode\"" % (
-                    self.path, texname))
-
+            silentstr = ""
+        if os.name == 'nt':
+            separator = "&" #Windows systems use & instead of ; in shell
+        else:
+            separator = ";"
+        cmd = ("cd \"%s\" %s latexmk \"%s\" %s -pdf "
+                "-latexoption=\"-interaction=nonstopmode\""
+                % (self.path, separator, texname, silentstr))
+        p = subprocess.Popen(cmd, shell=True)
+        p.wait()
+        if (p.returncode): #Non-zero return code from call to latexmk
+            print("latexmk run failed, see errors above ^^^")
+            print("trying pdflatex instead...")
+            cmd = ("cd \"%s\" %s pdflatex \"%s\" %s "
+                    "-latexoption=\"-interaction=nonstopmode\""
+                    % (self.path, separator, texname, silentstr))
+            p = subprocess.Popen(cmd, shell=True)
+            p.wait()
+            if (p.returncode): #Non-zero return code from call to latexmk
+                print("pdflatex run failed too, see errors above ^^^")
         pdfname = self.path + self.target
         assert os.path.isfile(pdfname)
         return pdfname

--- a/cvcreator/workspace.py
+++ b/cvcreator/workspace.py
@@ -105,15 +105,15 @@ class cvopen(object):
             self.template_not_found(template)
 
         with open(self.path + template + ".yaml") as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.load(f, Loader=yaml.SafeLoader)
 
     def get_content(self):
         with open(self.path + "_content") as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.load(f, Loader=yaml.SafeLoader)
 
     def get_config(self):
         with open(self.path + "config.yaml") as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.load(f, Loader=yaml.SafeLoader)
 
     def compile(self, textxt, silent):
 
@@ -144,7 +144,7 @@ class cvopen(object):
             cmd = ("cd \"%s\"" % (self.path)) + cmd + cmd
             p = subprocess.Popen(cmd, shell=True)
             p.wait()
-            if (p.returncode): #Non-zero return code from call to latexmk
+            if (p.returncode): #Non-zero return code from call to pdflatex
                 print("pdflatex run failed too, see errors above ^^^")
         pdfname = self.path + self.target
         assert os.path.isfile(pdfname)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ shutil.copy("config.yaml", "cvcreator/templates")
 
 setup(
     name="cvcreator",
-    version="0.4.4",
+    version="0.4.6",
     url="http://github.com/ExpertAnalytics/cvcreator",
 
     author="Jonathan Feinberg",


### PR DESCRIPTION
Added Windows compatibility (?!). 
Added call to pdflatex if latexmk fails. 
Specified Loader in call to yaml.load to avoid warning. 
Changed os.system to subprocess.Popen

Now a bit more verbose error messages instead of just an assertion error if pdf creation somehow fails.

The path to the temporary folder is now not a part of texname, but this should be safe since the cd changes the working directory of the subprocess to the temp folder before running latex.
