### PR TITLE
Adding deploy on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,7 @@
+version-tags: &version-tags
+  tags:
+    only: /v\d+\.\d+\.\d+/
+
 version: 2
 jobs:
   tests:
@@ -22,8 +26,29 @@ jobs:
               source venv/bin/activate
               pip install pytest
               pytest --doctest-modules cvcreator cvcreator/testsuite.py
+  deploy:
+    docker:
+      - image: circleci/python:3.7.3
+    steps:
+      - checkout
+      - run:
+          name: "Build wheel"
+          command: |
+              python setup.py sdist bdist_wheel --universal
+      - run:
+          name: "Publish to PyPI"
+          command: |
+              pip install twine
+              # twine upload --username jonathf --password $PYPI_PASSWORD dist/*
 workflows:
   version: 2
   workflow:
     jobs:
-      - tests
+      - tests:
+          filters:
+            <<: *version-tags
+      - deploy:
+          filters:
+            <<: *version-tags
+            # branches:
+            #     ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,15 @@ jobs:
       - run:
           name: "Build wheel"
           command: |
+              python -m venv venv
+              source venv/bin/activate
               python setup.py sdist bdist_wheel --universal
       - run:
           name: "Publish to PyPI"
           command: |
+              source venv/bin/activate
               pip install twine
-              # twine upload --username jonathf --password $PYPI_PASSWORD dist/*
+              twine upload --username jonathf --password $PYPI_PASSWORD dist/*
 workflows:
   version: 2
   workflow:
@@ -50,5 +53,5 @@ workflows:
       - deploy:
           filters:
             <<: *version-tags
-            # branches:
-            #     ignore: /.*/
+            branches:
+                ignore: /.*/

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ shutil.copy("config.yaml", "cvcreator/templates")
 
 setup(
     name="cvcreator",
-    version="0.4.6",
+    version="0.4.7",
     url="http://github.com/ExpertAnalytics/cvcreator",
 
     author="Jonathan Feinberg",


### PR DESCRIPTION
Instead of depending on maintainer with access right to deploy new version of the software to PyPI, this is now done automatically on tag releases.

For anyone with push rights to the repo:
* Bump version number in `setup.py`.
* After merge to `master` tag the release using the semantic version format: `git tag v{version number}`.
* Push tag to trigger deploy: `git push --tags`.

This assumes the version number follows the semantic versioning number scheme `{major}.{minor}.{micro}`. Any deviation to this will not trigger release.

Password to PyPI is added to CircleCI secrets.