### PR TITLE
Setuptools update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
           command: |
               python -m venv venv
               source venv/bin/activate
+              pip install -U setuptools
               python setup.py sdist bdist_wheel --universal
       - run:
           name: "Publish to PyPI"


### PR DESCRIPTION
When there is no dev-system for deploy (which is a bit overkill), there will be a little try and fail for deploying.
Like now, where the version of setuptools is out-of-date for deploying.