### PR TITLE
Add texlive-lang-european as debian-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For installation on Mac OS-X, see section below
 Prerequisite
 ------------
 System dependencies:
-- Latex (on Ubuntu/Debian: `sudo apt-get install latexmk texlive-latex-extra`)
+- Latex (on Ubuntu/Debian: `sudo apt-get install latexmk texlive-latex-extra texlive-lang-european`)
 - Python
 
 Python package dependencies:


### PR DESCRIPTION
This is needed to avoid: https://xal.slack.com/archives/C14QT6GQL/p1579614198000300