### PR TITLE
Sorting publications projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ $ cvcreate example.yaml -t<tab>
 banking   casual    classic   default   margin    oldstyle
 ```
 
+To include projects/publications use the flag -p/-u. Can either be called with specific keys:
+```
+cvcreate example.yaml -p="A1, foo, whatever"
+```
+where the added projects/publications will be added in selected order, or all can be included with:
+```
+cvcreate example.yaml -p="all"
+```
+
 For information about other options, see:
 ```
 $ cvcreate --help

--- a/cvcreator/cvcreate.py
+++ b/cvcreator/cvcreate.py
@@ -107,10 +107,9 @@ def main():
                 pub_keys = tuple_of_strings(args.publications, pub)
                 content["Publications"] = {}
                 for i, key in enumerate(pub_keys):
-                    try:
-                        content["Publications"][i] = pub[key]
-                    except KeyError:
+                    if key not in pub:
                         raise KeyError(f"Key {key} not found in Publications")
+                    content["Publications"][i] = pub[key]
 
             textxt = cv.parse(content, template)
 

--- a/cvcreator/cvcreate.py
+++ b/cvcreator/cvcreate.py
@@ -98,6 +98,7 @@ def main():
                     assert n < MAX_NUM_CONST, "Does not support cases for indices larger than MAX_NUM_CONST"
                     pi = "A%d" % i
                     if n in args.projects:
+                        ind = args.projects.index(i+1)
                         content["Projects"][pi] = proj.pop(pn)
             
             if not args.publications:
@@ -106,11 +107,13 @@ def main():
                 pub = content.pop("Publications", {})
                 content["Publications"] = {}
                 for i, un in enumerate(sorted(pub)):
+                    print(pub)
                     n = int(un[1:])
                     assert n < MAX_NUM_CONST, "Does not support cases for indices larger than MAX_NUM_CONST"
                     ui = "B%d" % i
                     if n in args.publications:
-                        content["Publications"][ui] = pub.pop(un)
+                        ind = args.publications.index(i+1)
+                        content["Publications"][ind] = pub.pop(un)
             
             textxt = cv.parse(content, template)
 

--- a/cvcreator/cvcreate.py
+++ b/cvcreator/cvcreate.py
@@ -10,7 +10,6 @@ import cvcreator as cv
 MAX_NUM_CONST = 100
 
 def tuple_of_strings(string, arg):
-    print(arg)
     if string == "all":
         return tuple(arg.keys())
     else:
@@ -97,7 +96,10 @@ def main():
                 proj_keys = tuple_of_strings(args.projects, proj)
                 content["Projects"] = {}
                 for i, key in enumerate(proj_keys):
-                    content["Projects"][i] = proj[key]
+                    try:
+                        content["Projects"][i] = proj[key]
+                    except KeyError:
+                        print("Key {} not found in Projects and therefore not included in the PDF".format(key))
 
             if not args.publications:
                 content.pop("Publications", None)
@@ -106,7 +108,10 @@ def main():
                 pub_keys = tuple_of_strings(args.publications, pub)
                 content["Publications"] = {}
                 for i, key in enumerate(pub_keys):
-                    content["Publications"][i] = pub[key]
+                    try:
+                        content["Publications"][i] = pub[key]
+                    except KeyError:
+                        print("Key {} not found in Publications and therefore not included in the PDF".format(key))
 
             textxt = cv.parse(content, template)
 

--- a/cvcreator/cvcreate.py
+++ b/cvcreator/cvcreate.py
@@ -99,7 +99,7 @@ def main():
                     try:
                         content["Projects"][i] = proj[key]
                     except KeyError:
-                        print("Key {} not found in Projects and therefore not included in the PDF".format(key))
+                        raise KeyError(f"Key {key} not found in Projects")
 
             if not args.publications:
                 content.pop("Publications", None)
@@ -111,7 +111,7 @@ def main():
                     try:
                         content["Publications"][i] = pub[key]
                     except KeyError:
-                        print("Key {} not found in Publications and therefore not included in the PDF".format(key))
+                        raise KeyError(f"Key {key} not found in Publications")
 
             textxt = cv.parse(content, template)
 

--- a/cvcreator/cvcreate.py
+++ b/cvcreator/cvcreate.py
@@ -96,10 +96,9 @@ def main():
                 proj_keys = tuple_of_strings(args.projects, proj)
                 content["Projects"] = {}
                 for i, key in enumerate(proj_keys):
-                    try:
-                        content["Projects"][i] = proj[key]
-                    except KeyError:
+                    if key not in proj:
                         raise KeyError(f"Key {key} not found in Projects")
+                    content["Projects"][i] = proj[key]
 
             if not args.publications:
                 content.pop("Publications", None)

--- a/cvcreator/cvcreate.py
+++ b/cvcreator/cvcreate.py
@@ -9,11 +9,13 @@ import cvcreator as cv
 
 MAX_NUM_CONST = 100
 
-def tuple_of_ints(string):
+def tuple_of_strings(string, arg):
+    print(arg)
     if string == "all":
-        return tuple(range(1, MAX_NUM_CONST))
+        return tuple(arg.keys())
     else:
-        return tuple(int(val) for val in string.split(","))
+        string = string.replace(" ", "")
+        return tuple(val for val in string.split(","))
 
 def main():
     parser = argparse.ArgumentParser(
@@ -39,11 +41,11 @@ def main():
         "-s", '--silent', action="store_true",
         help="Muffle output.")
     parser.add_argument(
-        "-p", "--projects", type=tuple_of_ints, 
-        default=(), help="Projects to include. Specify which entries by index or use 'all' to include all entries")
+        "-p", "--projects", type=str,
+        default=(), help="Projects to include. Specify which entries by keys or use 'all' to include all entries")
     parser.add_argument(
-        "-u", "--publications", type=tuple_of_ints, 
-        default=(), help="Publications to include. Specify which entris by integers or use all to inclue all entries.")
+        "-u", "--publications", type=str,
+        default=(), help="Publications to include. Specify which entries by keys or use all to inclue all entries.")
     parser.add_argument(
         "-lw", "--logo-width", type=str, dest="logo_width",
         help="Set the logo width.")
@@ -87,34 +89,25 @@ def main():
             content.update(config)
 
             template = src.get_template()
-            
+
             if not args.projects:
                 content.pop("Projects", None)
             else:
                 proj = content.pop("Projects", {})
+                proj_keys = tuple_of_strings(args.projects, proj)
                 content["Projects"] = {}
-                for i, pn in enumerate(sorted(proj)):
-                    n = int(pn[1:])
-                    assert n < MAX_NUM_CONST, "Does not support cases for indices larger than MAX_NUM_CONST"
-                    pi = "A%d" % i
-                    if n in args.projects:
-                        ind = args.projects.index(i+1)
-                        content["Projects"][pi] = proj.pop(pn)
-            
+                for i, key in enumerate(proj_keys):
+                    content["Projects"][i] = proj[key]
+
             if not args.publications:
                 content.pop("Publications", None)
             else:
                 pub = content.pop("Publications", {})
+                pub_keys = tuple_of_strings(args.publications, pub)
                 content["Publications"] = {}
-                for i, un in enumerate(sorted(pub)):
-                    print(pub)
-                    n = int(un[1:])
-                    assert n < MAX_NUM_CONST, "Does not support cases for indices larger than MAX_NUM_CONST"
-                    ui = "B%d" % i
-                    if n in args.publications:
-                        ind = args.publications.index(i+1)
-                        content["Publications"][ind] = pub.pop(un)
-            
+                for i, key in enumerate(pub_keys):
+                    content["Publications"][i] = pub[key]
+
             textxt = cv.parse(content, template)
 
             if args.latex:


### PR DESCRIPTION
Publications and projects are now added based on keys and not indices. By using "all" they are added in the order of the yaml file. If specific keys are selected they will be added in selected order.