### PR TITLE
Rewrite cvcreate with Jinja2 and pydantic

### DIFF
--- a/cvcreator/__main__.py
+++ b/cvcreator/__main__.py
@@ -1,0 +1,210 @@
+"""Main executable."""
+from typing import Any, Sequence
+import argparse
+import shutil
+import glob
+import tempfile
+import os
+import subprocess
+
+from jinja2 import Template
+
+from .schema import VitaeContent
+
+CURDIR = f"{os.path.dirname(__file__)}{os.path.sep}"
+TEMPLATES = [os.path.basename(path).replace(".tex", "")
+             for path in glob.glob(os.path.join(CURDIR, "templates", "*.tex"))]
+
+
+def filter_(idx_string: str, sequence: Sequence[Any]) -> Sequence[Any]:
+    """
+    Filter a sequence form CLI.
+
+    Args:
+        idx_string:
+            String with comma-separated integers. Or the string 'all'.
+        sequence:
+            Sequence of elements to filter.
+
+    Returns:
+        Same as `sequence`, but filtered down to indices included in
+        `idx_string`.
+
+    Examples:
+        >>> seq = list("ABCDEF")
+        >>> filter_("0,2,5", seq)
+        ['A', 'C', 'F']
+        >>> filter_("all", seq)
+        ['A', 'B', 'C', 'D', 'E', 'F']
+        >>> filter_("", seq)
+        []
+
+    """
+    if idx_string == "":
+        return []
+    if idx_string == "all":
+        return sequence
+    idx_string = idx_string.replace(" ", "")
+    return [sequence[int(val)] for val in idx_string.split(",")]
+
+
+def compile_(latex: str, source: str, output: str, silent: bool = True) -> None:
+    """
+    Compile latex code.
+
+    Will try to use latexmk first, then pdflatex.
+    Assumes that either of these executable exists.
+
+    Args:
+        latex:
+            The latex source code.
+        source:
+            The name of the latex source files.
+        output:
+            The folder for where to store output PDF.
+        silent:
+            Muffle latex compiles.
+
+    """
+    with tempfile.TemporaryDirectory() as folder:
+
+        with open(f"{folder}{os.path.sep}{source}", "w") as dst:
+            dst.write(latex)
+
+        sep = "&" if os.name == "nt" else ";"
+        silent = "-silent" if silent else ""
+        cmd_args = '{silent} -latexoption="-interaction=nonstopmode"'
+
+        proc = subprocess.Popen(
+            f'cd "{folder}" {sep} latexmk "{source}" {silent} '
+             '-pdf -latexoption="-interaction=nonstopmode"',
+            shell=True,
+        )
+        proc.wait()
+        if proc.returncode:
+            print("latexmk run failed, see errors above ^^^")
+            print("trying pdflatex instead...")
+            proc = subprocess.Popen(
+                f'cd "{folder}" {sep} pdflatex "{source}" '
+                 '{silent} -latexoption="-interaction=nonstopmode"',
+                shell=True
+            )
+            proc.wait()
+            if proc.returncode:
+                print("pdflatex run failed too, see errors above ^^^")
+                return
+
+        source = source.replace(".tex", ".pdf")
+        shutil.copy(f'{folder}{os.path.sep}{source}', output or source)
+
+
+def make_parser() -> argparse.ArgumentParser:
+    """Make an argument parser."""
+    parser = argparse.ArgumentParser(
+        description="A template based CV creater using YAML templates.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "source", type=str, nargs="?",
+        help="yaml source file to read. (If omitted create example source file.)"
+    ).completer = lambda prefix, **kws: glob.glob("*.yaml")
+    parser.add_argument(
+        "-t", "--template", type=str, default="default",
+        help="Select which latex template to use when generating document."
+    ).completer = lambda prefix, **kws: TEMPLATES
+    parser.add_argument(
+        "-o", "--output", type=str, default="",
+        help="Name of the output file. Default to 'source' with pdf-extension",
+    )
+    parser.add_argument(
+        "-l", '--latex', action="store_true",
+        help="Create latex instead of pdf."
+    )
+    parser.add_argument(
+        "-s", '--silent', action="store_true",
+        help="Muffle output.")
+    parser.add_argument(
+        "-p", "--projects", type=str, default="",
+        help="Projects to include. Specify which entries by index or use 'all' to include all entries")
+    parser.add_argument(
+        "-u", "--publications", type=str, default="",
+        help="Publications to include. Specify which entries by keys or use 'all' to include all entries.")
+    parser.add_argument(
+        "--font-size", type=int, default=11,
+        help="The size of the font used in the document."
+    )
+    parser.add_argument(
+        "--logo-image", type=str, default="logo",
+        help="path to image files compatible with latexpdf."
+    )
+    parser.add_argument(
+        "--footer-image", type=str, default="footer",
+        help="path to image files compatible with latexpdf."
+    )
+    return parser
+
+
+def main() -> None:
+    """Execution script."""
+    parser = make_parser()
+    args = parser.parse_args()
+
+    # no source, no problem: let's make one!
+    if not args.source:
+        with open(os.path.join(CURDIR, "templates", "example.yaml")) as src:
+            with open(args.source or "example.yaml", "w") as dst:
+                dst.write(src.read())
+        return
+
+    assert args.source.endswith(".yaml"), "must be YAML files with .yaml extension"
+    content = VitaeContent.load(args.source)
+
+    # filter projects and publications (as this can not be done in template)
+    content.project = filter_(args.projects, content.project)
+    content.publication = filter_(args.publications, content.publication)
+
+    # verify paths to templates and images
+    template = (os.path.join(CURDIR, "templates", f"{args.template}.tex")
+                if args.template in TEMPLATES else args.template)
+    assert os.path.isfile(template), (
+        "template '%s' not valid path" % args.template)
+
+    footer_image = (args.footer_image if os.path.isfile(args.footer_image)
+                    else os.path.join(CURDIR, "templates",
+                                      f"{args.footer_image}.pdf"))
+    assert os.path.isfile(footer_image), (
+        "footer_image '%s' not valid path" % args.footer_image)
+
+    logo_image = (args.logo_image if os.path.isfile(args.logo_image)
+                  else os.path.join(CURDIR, "templates",
+                                    f"{args.logo_image}.pdf"))
+    assert os.path.isfile(logo_image), (
+        "logo_image '%s' not valid path" % args.logo_image)
+
+    # Merge source and template:
+    with open(template, "r") as src:
+         template = Template(
+            src.read(),
+            block_start_string="\\BLOCK{",
+            block_end_string="}",
+            variable_start_string="\\VAR{",
+            variable_end_string="}",
+        )
+    latex = template.render(
+        logo_image=logo_image,
+        footer_image=footer_image,
+        font_size=args.font_size,
+        **dict(content),
+    )
+
+    # (compile and) store results:
+    output = args.output or args.source.replace(".yaml", ".tex")
+    if args.latex:
+        with open(output, "w") as dst:
+            dst.write(latex)
+    else:
+        compile_(
+            latex=latex,
+            source=args.source.replace(".yaml", ".tex"),
+            output=output,
+            silent=args.silent,
+        )

--- a/cvcreator/schema.py
+++ b/cvcreator/schema.py
@@ -49,6 +49,7 @@ class Project(BaseModel):
     period: str
     tools: str
     description: str
+    tag: str
 
 class Publications(BaseModel):
     """Published journal papers."""
@@ -58,6 +59,7 @@ class Publications(BaseModel):
     doi: str
     authors: str
     year: int
+    tag: str
 
 class VitaeContent(BaseModel):
     """Schema for the yaml source file."""

--- a/cvcreator/schema.py
+++ b/cvcreator/schema.py
@@ -1,0 +1,86 @@
+"""Schema definition for the user provided yaml source file."""
+from typing import List, Tuple
+from pydantic import BaseModel, Field
+import yaml
+
+
+class TechnicalSkill(BaseModel):
+    """Group of technical skills."""
+
+    title: str
+    values: List[str]
+
+class LanguageSkill(BaseModel):
+    """Language skill and proficiency."""
+
+    language: str
+    proficiency: str
+
+class PersonalSkill(BaseModel):
+    """A personal skill and description."""
+
+    title: str
+    description: str
+
+class Hobby(BaseModel):
+    """Group of hobbies."""
+
+    title: str
+    values: List[str]
+
+class Education(BaseModel):
+    """Completed educational degree."""
+
+    year: str
+    description: str
+
+class Work(BaseModel):
+    """Previous work experience."""
+
+    period: Tuple[str, str]
+    description: str
+
+class Project(BaseModel):
+    """Extended description of a project."""
+
+    activity: str
+    role: str
+    staffing: str
+    period: str
+    tools: str
+    description: str
+
+class Publications(BaseModel):
+    """Published journal papers."""
+
+    journal: str
+    title: str
+    doi: str
+    authors: str
+    year: int
+
+class VitaeContent(BaseModel):
+    """Schema for the yaml source file."""
+
+    name: str
+    address: str = ""
+    post: str = ""
+    birth: str = ""
+    email: str = ""
+    phone: str = ""
+    nationality: str = ""
+    summary: str = ""
+
+    technical_skill: List[TechnicalSkill] = Field(default_factory=list)
+    language_skill: List[LanguageSkill] = Field(default_factory=list)
+    personal_skill: List[PersonalSkill] = Field(default_factory=list)
+    hobby: List[Hobby] = Field(default_factory=list)
+    education: List[Education] = Field(default_factory=list)
+    work: List[Work] = Field(default_factory=list)
+    project: List[Project] = Field(default_factory=list)
+    publication: List[Publications] = Field(default_factory=list)
+
+    @staticmethod
+    def load(path: str) -> "VitaeContent":
+        with open(path) as src:
+            return VitaeContent(**yaml.safe_load(src))

--- a/cvcreator/templates/default.tex
+++ b/cvcreator/templates/default.tex
@@ -1,0 +1,161 @@
+\documentclass[english,a4paper,\VAR{font_size}pt]{article}
+\usepackage[margin=3cm,a4paper]{geometry}
+\usepackage{graphicx}
+\usepackage{amssymb}
+\usepackage[utf8]{inputenc}
+\usepackage[norsk]{babel}
+\usepackage{color}
+\usepackage{xcolor}
+\usepackage{array}
+\usepackage{wrapfig}
+\usepackage{calc}
+\usepackage{hyperref}
+\usepackage{xspace}
+\usepackage{parskip}
+\usepackage{fancyhdr}
+\usepackage{longtable}
+\usepackage{needspace} \def\cvneedspaceconst{5}
+\fancyhf{}
+\renewcommand{\headrulewidth}{0pt}
+\cfoot[\fancyplain{}{\footnotesize\thepage}]{
+    \includegraphics[width=5cm]{\VAR{footer_image}}}
+\definecolor{xalblue}{rgb}{0.1719,0.3516,0.6250}
+\definecolor{xaldark}{rgb}{0.1290,0.2566,0.4688}
+\definecolor{lightgray}{gray}{0.8}
+\renewcommand*{\familydefault}{\sfdefault}
+\newcolumntype{L}{>{\raggedright}p{0.16\textwidth}}
+\newcolumntype{R}{p{0.74\textwidth}}
+\newcommand\VRule{\color{lightgray}\vrule width 0.5pt}
+\usepackage{titlesec}
+\newcommand\secformat[1]{\normalfont\Large\bfseries\color{xalblue}#1}
+\titleformat{name=\section}[block]{}{}{}{\secformat}
+
+\begin{document}
+\pagestyle{fancy}
+\pagenumbering{gobble}
+\vspace*{-2cm}
+
+\hspace*{10cm}\includegraphics[width=6cm]{ \VAR{logo_image} }
+\vspace*{1cm}
+
+\noindent
+{\LARGE \bfseries \color{xaldark} Curriculum Vitae for \VAR{name} }
+
+\Needspace{\cvneedspaceconst\baselineskip}
+
+\section*{Personal information}
+
+\begin{minipage}[t]{0.4\textwidth}
+\begin{tabbing}Nationality---\=olaf\kill
+\BLOCK{if address} Address: \>\VAR{address} \\ \BLOCK{endif}
+\BLOCK{if post}             \>\VAR{post}    \\ \BLOCK{endif}
+\BLOCK{if birth}   Birth:   \>\VAR{birth}   \\ \BLOCK{endif}
+\end{tabbing}
+\end{minipage}
+$\quad\quad$
+\begin{minipage}[t]{0.3\textwidth}
+\begin{tabbing}Nationality---\=olaf\kill
+\BLOCK{if email}       E-mail:      \>\VAR{address}     \\ \BLOCK{endif}
+\BLOCK{if phone}       Phone:       \>\VAR{phone}       \\ \BLOCK{endif}
+\BLOCK{if nationality} Nationality: \>\VAR{nationality} \\ \BLOCK{endif}
+\end{tabbing}
+\end{minipage}
+
+\BLOCK{if summary}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Summary}
+\VAR{summary}
+\BLOCK{endif}
+
+\BLOCK{if technical_skill}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Technical skills}
+\begin{longtable}{LR}
+\BLOCK{for s in technical_skill}
+\VAR{s.title} & \VAR{s.values|join(", ")} \\
+\BLOCK{endfor}
+\end{longtable}
+\BLOCK{endif}
+
+\BLOCK{if education}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Education}
+\begin{longtable}{LR}
+\BLOCK{for s in education}
+\VAR{s.year} & \VAR{s.description} \\
+\BLOCK{endfor}
+\end{longtable}
+\BLOCK{endif}
+
+\BLOCK{if work}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Professional experience}
+\begin{longtable}{LR}
+\BLOCK{for s in work}
+\VAR{s.period[0]} -- \VAR{s.period[1]} & \VAR{s.description} \\
+\BLOCK{endfor}
+\end{longtable}
+\BLOCK{endif}
+
+\BLOCK{if language_skill}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Languages}
+\begin{longtable}{LR}
+\BLOCK{for s in language_skill}
+\VAR{s.language} & \VAR{s.proficiency} \\
+\BLOCK{endfor}
+\end{longtable}
+\BLOCK{endif}
+
+\BLOCK{if personal_skill}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Personal skills}
+\begin{longtable}{LR}
+\BLOCK{for s in personal_skill}
+\VAR{s.title} & \VAR{s.description} \\
+\BLOCK{endfor}
+\end{longtable}
+\BLOCK{endif}
+
+\BLOCK{if hobby}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Some interests and hobbies}
+\begin{longtable}{LR}
+\BLOCK{for s in hobby}
+\VAR{s.title} & \VAR{s.values|join(", ")} \\
+\BLOCK{endfor}
+\end{longtable}
+\BLOCK{endif}
+
+\BLOCK{if project}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Extended description of selected projects}
+
+\BLOCK{for s in project}
+\begin{longtable}{@{}LR}
+Activity    & \VAR{s.activity}    \\
+Period      & \VAR{s.period}      \\
+Role        & \VAR{s.role}        \\
+Staffing    & \VAR{s.staffing}    \\
+Description & \VAR{s.description} \\
+Tools       & \VAR{s.tools}       \\
+\end{longtable}
+\BLOCK{endfor}
+\BLOCK{endif}
+
+\BLOCK{if publication}
+\Needspace{\cvneedspaceconst\baselineskip}
+\section*{Publications}
+
+\BLOCK{for s in publication}
+\begin{longtable}{@{}LR}
+Journal & \VAR{s.journal}     \\
+Title   & {\it \VAR{s.title}} \\
+DOI     & \VAR{s.doi}         \\
+Authors & \VAR{s.authors}     \\
+Year    & \VAR{s.year}        \\
+\end{longtable}
+\BLOCK{endfor}
+\BLOCK{endif}
+
+\end{document}

--- a/cvcreator/templates/example.yaml
+++ b/cvcreator/templates/example.yaml
@@ -61,6 +61,7 @@ project:
       tools: "tool1, tool2, ..."
       description: >
           short description of project and your involvement
+      tag: "tag1"
 
 publication:
     - journal: "title of journal"
@@ -70,3 +71,4 @@ publication:
       doi: "the DOI link to the work"
       summary: >
           brief summary of work
+      tag: "tag2"

--- a/cvcreator/templates/example.yaml
+++ b/cvcreator/templates/example.yaml
@@ -1,0 +1,72 @@
+name:  "name"
+address: "address"
+post: "zip/post + city"
+birth: "birthdate"
+email: "email adresse"
+phone: "phone number"
+nationality: "Norwegian"
+summary: >
+    a short description of who you are
+    over multiple line if you wanna.
+
+technical_skill:
+    - title: Languages
+      values: ["programming language", ...]
+    - title: Frameworks
+      values: ["framework", ...]
+
+language_skill:
+    - language: "Norwegian"
+      proficiency: "how well you speak/write"
+    - language: "English"
+      proficiency: "how well you speak/write"
+
+personal_skill:
+    - title: "Technology"
+      description: "short description of skill"
+    - title: "Communication"
+      description: "short description of skill"
+
+hobbies:
+    - title: "topic1"
+      values: ["topic element", ...]
+    - title: "topic2"
+      values: ["topic element", ...]
+
+education:
+    - year: 2020
+      description: "description of completed degree"
+    - year: 2017
+      description: "description of completed degree"
+work:
+    - period: [2018, ""]
+      description: "description of work"
+    - period: [2016, 2018]
+      description: "description of old work"
+
+interests:
+    "topic1":
+        - "topic element"
+        - ...
+    "toptic2":
+        - "topic element"
+        - ...
+
+project:
+    - activity: "project title"
+      period: "2019 -- 2020"
+      role: "your role in project"
+      staffing: "who worked on project"
+      volume: "Volume of work (eg. percent of full time)"
+      tools: "tool1, tool2, ..."
+      description: >
+          short description of project and your involvement
+
+publication:
+    - journal: "title of journal"
+      year: 2020
+      authors: "author1, author2, ..."
+      title: "the title of the work"
+      doi: "the DOI link to the work"
+      summary: >
+          brief summary of work

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ shutil.copy("config.yaml", "cvcreator/templates")
 
 setup(
     name="cvcreator",
-    version="0.4.9",
+    version="1.0-alpha0",
     url="http://github.com/ExpertAnalytics/cvcreator",
 
     author="Jonathan Feinberg",
@@ -23,13 +23,12 @@ setup(
     package_data={"cvcreator": ["templates/*"]},
     entry_points={
         "console_scripts": [
+            "_cvcreate = cvcreate.__main__:main",
             "cvcreate = cvcreator.cvcreate:main",
             "txt2yaml = cvcreator.txt2yaml:main",
         ]
     },
-    install_requires=[
-        "pyyaml",
-    ],
+    install_requires=["pyyaml", "pydantic", "jinja2"],
     zip_safe=False,
 )
 


### PR DESCRIPTION
Current implementation of cvcreate is a bit of a mess.
So I rewrote it, but tried to use some known tools along the way to make it better.

Jinja
-----

Jinja is a known templating tool spun out of Django. With some (recommended) modified defaults it allows us to create latex templates with valid latex syntax.
In practice we use `\VAR{ ... }` to inserts a variable, and `\BLOCK{ ... }` is an evaluation block.
In addition to standardizing the format, it has allowed us to move processing blocks like string-interpolation and conditional blocks into the template format.

Pydantic
--------

Verifying what the user brings to the table is not done much right now.
Pydantic improves on this by validating input against annotation.

YAML source scheme
------------------

As noted in #42, the format we are currently using is problematic. This
Pydantic+Jinja solution requires us to change it a bit.
See new `example.yaml` to see the new format.

New flag features
-----------------

The new parser (which is mostly a copy of the old one, with less bloat),
has removed some old flags (like logo position), and instead introduces:

`--logo-image`: use a custom logo image (or personal image)
`--footer-image`: use a custom footer image (set it to `footer_de` for Vinz)
`--font-size`: use non-default font-size.

These are added as a proof-of-concept. We can easily add lots of more stuff later.