### PR TITLE
Fix/toml example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Start by creating a simple example:
 
 .. code:: sh
 
-  cv toml example.toml
+  cv example example.toml
 
 Edit the resulting ``example.toml`` file with your favorite text editor.
 This is the content file which will be inserted into the final CV output.

--- a/cvcreator/parser.py
+++ b/cvcreator/parser.py
@@ -112,7 +112,7 @@ def example(toml_target):
     Create example .toml content file to be filled out.
     """
     toml_source = os.path.join(os.path.dirname(__file__), "templates", "example.toml")
-    shutil.copy(pdf_path, toml_target)
+    shutil.copy(toml_source, toml_target)
 
 
 @cv.command(cls=HelpColorsCommand, short_help="List technical skill badges")


### PR DESCRIPTION
The README referred to an unknown CLI `toml`, which seems like it should be `example`.
Also the example interface function contained an undefined variable.

 