### PR TITLE
Fix/pdf generation

### DIFF
--- a/cvcreator/templates/default.tex
+++ b/cvcreator/templates/default.tex
@@ -89,12 +89,10 @@
 \BLOCK{endif}
 
 \BLOCK{if technical_skill}
-  \section*{Technical skills}
-  {\renewcommand{\arraystretch}{1.4}
+  \section*{Technical skills}{
   \begin{tabular}{LR}
     \BLOCK{for s in technical_skill}
     \VAR{s.title} & \VAR{s.values|join("\\nobreak\\divbar{}")} \\
-    \hline
     \BLOCK{endfor}
   \end{tabular}}
 \BLOCK{endif}

--- a/cvcreator/templates/default.tex
+++ b/cvcreator/templates/default.tex
@@ -92,7 +92,7 @@
   \section*{Technical skills}{
   \begin{tabular}{LR}
     \BLOCK{for s in technical_skill}
-    \VAR{s.title} & \VAR{s.values|join("\\nobreak\\divbar{}")} \\
+    \VAR{s.title} & \VAR{s.values|join(", ")} \\
     \BLOCK{endfor}
   \end{tabular}}
 \BLOCK{endif}

--- a/cvcreator/templates/default.tex
+++ b/cvcreator/templates/default.tex
@@ -56,7 +56,7 @@
   % XAL logo
   \vspace{-1.4cm}
   \hspace{3cm}
-  \includegraphics[width=6cm]{ \VAR{meta.logo_image} }
+  \includegraphics[width=6cm]{\VAR{meta.logo_image}}
 \end{tabular}
 
 \vspace{2cm}


### PR DESCRIPTION
Remove space that causes errors in pdf generation. (See https://tex.stackexchange.com/questions/233249/unknown-graphics-extension-png-pdf for a description of the problem and the solution)

Remove hline between technical skills and adapt the vertical spacing in this section so that it fits the rest.