### PR TITLE
propose new formatting for hyperlinks

### DIFF
--- a/cvcreator/templates/vitae.tex
+++ b/cvcreator/templates/vitae.tex
@@ -7,6 +7,13 @@
 \usepackage{amssymb}          % math symbols
 \usepackage{hyperref}         % make URL links
 
+% Format hyperlinks
+\hypersetup {
+  colorlinks=true,
+  linkcolor=[rgb]{0,0.5,0.5},
+  urlcolor=blue,
+}
+
 % add footer image
 \usepackage{fancyhdr}
 \renewcommand{\headrulewidth}{0pt} % because fancyhdr usually makes a topline


### PR DESCRIPTION
This is the similar to PR #81, but the link's text is the same as the link's url so that printed CVs still show the url. 

I am proposing a new formatting for links. The links won't have a big light blue rectangular shape around them, but will look like real links in a webpage. 

The following is not implemented in this PR but It would be possible to strip `https://` from the link text by using the following code. I am not sure if this is desirable. For example, my GitHub url would show `aless80.github.io` instead of `https://aless80.github.io`
```
\usepackage{xstring}
..
\href{\VAR{github}}{\StrSubstitute{\VAR{github}}{https://}}
```