### PR TITLE
Fix pdf file name in output message

### DIFF
--- a/cvcreator/compile.py
+++ b/cvcreator/compile.py
@@ -12,6 +12,7 @@ import click
 def compile_latex(
     latex: str,
     name: str = "document",
+    output: str = "",
     silent: bool = False,
 ) -> Iterator[str]:
     """
@@ -25,7 +26,9 @@ def compile_latex(
             The latex source code as a string.
         name:
             The name of the file to be used during compilation.
-            The extensions `.tex` and `.pdf` will be added.
+            The extension `.tex` will be added.
+        output:
+            The name of the output file e.g. `mycv.pdf`.
         silent:
             Muffle latex compiles.
 
@@ -62,5 +65,5 @@ def compile_latex(
                 sys.exit(2)
         if not silent:
             click.secho(
-                f"Document successfully compiled: {name}.tex -> {name}.pdf", fg="green")
+                f"Document successfully compiled: {name}.tex -> {output}", fg="green")
         yield source_file.replace(".tex", ".pdf")

--- a/cvcreator/parser.py
+++ b/cvcreator/parser.py
@@ -72,7 +72,7 @@ def create(
     else:
         name = os.path.basename(toml_content.replace(".toml", ""))
         output = output or toml_content.replace(".toml", ".pdf")
-        with compile_latex(latex=latex_code, name=name) as pdf_path:
+        with compile_latex(latex=latex_code, name=name, output=output) as pdf_path:
             shutil.copy(pdf_path, output)
 
 


### PR DESCRIPTION
See #116 
Now it is good
```
$ cv create ./AlessandroMarin_AI_Bymiljo.toml out.pdf -p : --norwegian

Document successfully compiled: AlessandroMarin_AI_Bymiljo.tex -> out.pdf


$ cv create ./AlessandroMarin_AI_Bymiljo.toml  -p : --norwegian

..
Document successfully compiled: AlessandroMarin_AI_Bymiljo.tex -> ./AlessandroMarin_AI_Bymiljo.pdf

```