### PR TITLE
Skills grouped by user

### DIFF
--- a/cvcreator/templates/example.toml
+++ b/cvcreator/templates/example.toml
@@ -15,7 +15,17 @@ fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum.
 """
 
-technical_skill = [ "Python", "C++", "Java", "Numpy", "Scipy", "Statsmodels", "PyMC"]
+[[skills_category]]
+category = "Tools"
+technical_skills = [
+    "Numpy", "PyMC", "Scipy", "Statsmodels",
+]
+[[skills_category]]
+category = "Languages"
+technical_skills = [
+    "C++", "Java", "Python",
+]
+
 
 [[work]]
 description = "Computer scientist at Google Inc."

--- a/cvcreator/vitae/content.py
+++ b/cvcreator/vitae/content.py
@@ -4,7 +4,7 @@ from typing import Any, List, Sequence
 import toml
 from .schema import VitaeContent, NorwegianVitaeContent
 from .schema import TechnicalSkill
-from .tech_skills import make_skill_groups, get_skills_data
+from .tech_skills import make_skill_groups, get_skills_data, get_skills
 
 CURDIR = f"{os.path.dirname(__file__)}{os.path.sep}"
 
@@ -75,8 +75,17 @@ def load_vitae(
     # remove potential duplicates from technical skills
     content.technical_skill = list(set(content.technical_skill))
 
-    # place technical skills into groups
-    content.technical_skill = make_skill_groups(content.technical_skill)
+    # Process technical skills
+    if len(content.technical_skill) > 0 and len(content.skills_category) > 0:
+        raise ValueError("Cannot process skills in from both `technical_skill` or in `skills_category`")
+    elif len(content.technical_skill) > 0:
+        # place technical skills into groups
+        content.technical_skill = make_skill_groups(content.technical_skill)
+    elif len(content.skills_category) > 0:
+        # get technical skills grouped by user-defined categories
+        content.technical_skill = get_skills(content.skills_category)
+    else:
+        raise ValueError("Unexpected values for `content.technical_skill` and `content.skills_category`")
 
     if norwegian:
         norwegian_labels = get_skills_data()["norwegian_labels"]

--- a/cvcreator/vitae/schema.py
+++ b/cvcreator/vitae/schema.py
@@ -77,6 +77,13 @@ class TechnicalSkill(StrictModel):
     values: List[str]
 
 
+class SkillCategory(StrictModel):
+    """Group of skills under the same category."""
+
+    category: str
+    technical_skills: List[str]
+
+
 class LanguageSkill(StrictModel):
     """Language skill and proficiency."""
 
@@ -274,6 +281,8 @@ class VitaeContent(StrictModel):
     # 'str' is used here as a placeholder for list of skills.
     technical_skill: Union[List[str], List[TechnicalSkill]] = (
         Field(default_factory=list))
+    # Skills structure alternative to `technical_skill`: skills grouped by user-defined categories
+    skills_category: List[SkillCategory] = Field(default_factory=list)
 
     language_skill: List[LanguageSkill] = Field(default_factory=list)
     personal_skill: List[PersonalSkill] = Field(default_factory=list)

--- a/cvcreator/vitae/tech_skills.py
+++ b/cvcreator/vitae/tech_skills.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import toml
 
-from .schema import TechnicalSkill
+from .schema import TechnicalSkill, SkillCategory
 
 CURDIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -60,11 +60,7 @@ def make_skill_groups(
             count[label] += 1
     max_count = max(count.values())+1
 
-    skills = list(skills)
-    unknown_skills = set(skills).difference(skills_data["skills"])
-    assert not unknown_skills, (
-            f"unrecognized technical skills: {sorted(unknown_skills)}"
-            "\nPrint out all available technical skills with `cv skills`")
+    _validate_skills(skills, skills_data)
 
     output = {}
     while skills:
@@ -92,3 +88,49 @@ def make_skill_groups(
     output = [TechnicalSkill(title=title, values=output[title])
               for title in skills_data["allowed_labels"] if title in output]
     return output
+
+
+def get_skills(skill_categories: List[SkillCategory]) -> List[TechnicalSkill]:
+    """Process skills organized in skill categories into a list of `TechnicalSkill` objects
+
+    Args:
+        skill_categories:
+            User provided skills to distribute into groups.
+
+    Returns:
+        List of TechnicalSkill objects
+    """
+    output: List[TechnicalSkill] = []
+
+    # Get technical skills data
+    skills_data = get_skills_data()
+
+    # Process the skill categories in the CV
+    for skill_category in skill_categories:
+        label = skill_category.category
+        skills = skill_category.technical_skills
+        # Validation of skill categories and skills
+        if label not in skills_data["allowed_labels"]:
+            raise ValueError(f"{label}: Invalid skill label")
+        _validate_skills(skills, skills_data)
+
+        output.append(TechnicalSkill(title=label, values=skills))
+
+    return output
+
+
+def _validate_skills(skills: Sequence[str], skills_data: dict[str, Any]):
+    """Check that skills are valid.
+
+    Compare a list of skill strings against a data structure containing allowed skills.
+
+    Args:
+        skills:
+             List of skills.
+        skills_data:
+            Technical skills data.
+    """
+    unknown_skills = set(skills).difference(skills_data["skills"])
+    assert not unknown_skills, (
+        f"unrecognized technical skills: {sorted(unknown_skills)}"
+        "\nPrint out all available technical skills with `cv skills`")


### PR DESCRIPTION
Refer to #120 , where I propose to let the user group technical skills as they want (as long as categories and skills are listed in `tech_skills.toml`).

This PR adds an new syntax for technical skills. Note that
1. The old skills syntax option based on the `technical_skill` keyword still works, i.e. old CVs will still be working.
2. If in addition to the old skills syntax also the new  one is present, `cv create` throws an error, i.e. the new and old syntaxes are incompatible.

This PR passes the tests, but I haven't added more. I changed the output of `cv example` to the new syntax.

Example:
Create a pdf  with `cv create --norwegian out.pdf` using the new syntax. Then uncomment `technical_skill` and comment `[[skills_category]]`, and compare the results (see the picture below).
```
name = "Alessandro Marin, Doktorgrad"
summary = """
Fysiker med sterk kompetanse innen bla
"""
#technical_skill = [
#"Scikit-Learn", "XGBoost", "Seaborn", "Scipy",
#"Pydantic", "Pytest", "Pandas", "Numpy", "Git",
#"Python", "Bash", "Typescript",
#"Azure Devops", "Terraform", "Docker", "Kubernetes",
#"Javascript", "HTML", "REST API", "Angular",
#"Linux",
#]
[[skills_category]]
category = "ML"
technical_skills = ["Scikit-Learn", "XGBoost", "Seaborn", "Scipy",]

[[skills_category]]
category = "Tools"
technical_skills = ["Pydantic", "Pytest", "Pandas", "Numpy", "Git",]

[[skills_category]]
category = "Languages"
technical_skills = ["Python", "Bash", "Typescript",]

[[skills_category]]
category = "Cloud"
technical_skills = ["Azure Devops", "Terraform", "Docker", "Kubernetes",]

[[skills_category]]
category = "Web"
technical_skills = ["Javascript", "HTML", "REST API", "Angular", ]

[[skills_category]]
category = "Platforms"
technical_skills = ["Linux",]
```
Left: pdf using the old syntax. Right: pdf using the new syntax.
![Selection_048](https://github.com/user-attachments/assets/ae933e24-bc7d-436a-b0e4-b7d4a3eb7c21)