### PR TITLE
chore: bump version to 1.1.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cvcreator"
-version = "1.1.16"
+version = "1.1.17"
 description = "An automated tool for creating CVs on the fly."
 authors = ["Jonathan Feinberg <jonathf@gmail.com>"]
 license = "mit"


### PR DESCRIPTION
Note that the package version is still on 1.1.15 on [pypi](https://pypi.org/project/cvcreator/) and not 1.1.16 as it should be. All changes after release 1.1.15 have not been created and deployed as part of the package. The issue could be due to a manual release triggered [here](https://github.com/expertanalytics/cvcreator/releases/tag/v1.1.16). `release`action seems to not have been triggered for a year.

Also tested locally by pip installing the package and the skills added after 1.1.15 are indeed missing.

Lets try this change to see if a new release is automatically triggered.

Note this may be slightly awkward as 1.1.16 will not be on pypi, instead a version 1.1.17 will show, but this should not be too big of an issue.

Another thing to note is that contributors should be more proactive in bumping the version as instructed in the "Deployment" section of the readme.

